### PR TITLE
Improve errors log and throw TooManyRequetsError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Log error object instead of only the status code
+- Throw TooManyRequetsError to Colossus when Crowdin return 429
 
 ## [0.6.0] - 2019-11-25
 ### Added

--- a/node/middlewares/listenToUpdates.ts
+++ b/node/middlewares/listenToUpdates.ts
@@ -18,7 +18,7 @@ export async function logUpdateInTranslations(ctx: Context, next: () => Promise<
   const stringId = stringCrowdinId.crowdinId
   const srcMessageInfoFromCrowdin = await crowdin.getString(stringId, body.project_id)
   if(srcMessageInfoFromCrowdin.err) {
-    logger.error('Error getting updated message from Crowdin')
+    logger.error(srcMessageInfoFromCrowdin.err)
     return
   }
   const srcMessage = (srcMessageInfoFromCrowdin.res as CrowdinGetStringResponse).data.text
@@ -27,14 +27,14 @@ export async function logUpdateInTranslations(ctx: Context, next: () => Promise<
   const targetMessageCrowdinId = body.translation_id
   const targetMessageInfoFromCrowdin = await crowdin.getTranslation(targetMessageCrowdinId, body.project_id)
   if(targetMessageInfoFromCrowdin.err) {
-    logger.error('Error getting updated message from Crowdin')
+    logger.error(targetMessageInfoFromCrowdin.err)
     return
   }
   const targetMessage = (targetMessageInfoFromCrowdin.res as CrowdinGetTranslationResponse).data.text
 
   const projectInfoFromCrowdin = await crowdin.getProject(body.project_id)
   if(projectInfoFromCrowdin.err) {
-    logger.error('Error getting project info from Crowdin')
+    logger.error(projectInfoFromCrowdin.err)
     return
   }
   const srcLang = (projectInfoFromCrowdin.res as CrowdinGetProjectResponse).data.sourceLanguageId


### PR DESCRIPTION
- Log error object instead of only the status code
- Throw TooManyRequetsError to Colossus when Crowdin return 429